### PR TITLE
Feat: Disable notifications for offline server states

### DIFF
--- a/src/ark_discord_bot/server_monitor.py
+++ b/src/ark_discord_bot/server_monitor.py
@@ -87,17 +87,6 @@ class ServerMonitor:
 
             if current_status == "running" and previous_status != "running":
                 message = "🟢 ARKサーバーが接続準備完了しました！ 🦕"
-            elif current_status == "starting" and previous_status == "not_ready":
-                message = "🟡 ARKサーバーポッドが稼働中、ゲームサーバー起動中..."
-            elif (
-                current_status in ["not_ready", "starting"]
-                and previous_status == "running"
-            ):
-                message = "🟡 ARKサーバーが再起動中または準備未完了です..."
-            elif current_status == "error":
-                message = (
-                    "🔴 ARKサーバーでエラーが発生しました！ログを確認してください。"
-                )
 
             if message:
                 await self.discord_bot.send_message(self.channel_id, message)


### PR DESCRIPTION
This pull request disables notifications for when the server is in an offline state (starting, not_ready, error). This ensures that notifications are only sent when the server is fully running and connectable.

This change modifies `server_monitor.py` to only send a notification when the server status changes to "running".