### PR TITLE
feat: add confirmation dialog for server restart command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,33 @@ This project follows TDD principles with 37 comprehensive test cases. Always:
 2. Write tests for new functionality
 3. Use mocking for external dependencies (K8s API, RCON, Discord)
 
+### Code Quality and Pre-commit Checks
+**IMPORTANT**: Before making any commits, ALWAYS run the following commands to ensure code quality:
+
+```bash
+# 1. Format code (required)
+uv run black src/ tests/
+uv run isort src/ tests/
+
+# 2. Run linting (required) 
+uv run pylint src/ark_discord_bot/
+
+# 3. Run all tests (required)
+uv run pytest tests/ -v
+
+# Alternative: Use Makefile for all checks
+make format && make lint && make test
+```
+
+**Commit Workflow:**
+1. Make code changes
+2. Run formatting: `uv run black src/ tests/ && uv run isort src/ tests/`
+3. Check linting: `uv run pylint src/ark_discord_bot/`
+4. Run tests: `uv run pytest tests/ -v`
+5. Only commit if all checks pass
+
+This ensures all commits maintain code quality and don't break existing functionality.
+
 ### Error Handling
 Follow existing patterns:
 - Comprehensive try/catch blocks

--- a/src/ark_discord_bot/discord_bot.py
+++ b/src/ark_discord_bot/discord_bot.py
@@ -13,6 +13,62 @@ from .server_status_checker import ServerStatusChecker
 logger = logging.getLogger(__name__)
 
 
+class RestartConfirmationView(discord.ui.View):
+    """View for restart confirmation dialog."""
+
+    def __init__(self, bot: 'ArkDiscordBot', timeout=60):
+        super().__init__(timeout=timeout)
+        self.bot = bot
+        self.confirmed = False
+
+    @discord.ui.button(label='再起動する', style=discord.ButtonStyle.danger, emoji='🔄')
+    async def confirm_restart(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Handle restart confirmation."""
+        self.confirmed = True
+        
+        # Disable all buttons
+        for item in self.children:
+            item.disabled = True
+        
+        await interaction.response.edit_message(
+            content="🔄 ARKサーバーの再起動を開始しています...",
+            view=self
+        )
+        
+        try:
+            success = await self.bot.kubernetes_manager.restart_server()
+            
+            if success:
+                await interaction.followup.send(
+                    "✅ ARKサーバーの再起動を開始しました！サーバーがオンラインに戻るまでしばらくお待ちください。"
+                )
+            else:
+                await interaction.followup.send(
+                    "❌ ARKサーバーの再起動に失敗しました。ログを確認するか管理者にお問い合わせください。"
+                )
+        except Exception as e:
+            logger.error(f"Error during server restart: {e}")
+            await interaction.followup.send("❌ サーバー再起動中にエラーが発生しました。")
+
+    @discord.ui.button(label='キャンセル', style=discord.ButtonStyle.secondary, emoji='❌')
+    async def cancel_restart(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Handle restart cancellation."""
+        # Disable all buttons
+        for item in self.children:
+            item.disabled = True
+        
+        await interaction.response.edit_message(
+            content="❌ ARKサーバーの再起動がキャンセルされました。",
+            view=self
+        )
+
+    async def on_timeout(self):
+        """Handle timeout."""
+        # Disable all buttons
+        for item in self.children:
+            item.disabled = True
+
+
 class ArkDiscordBot(commands.Bot):
     """Discord bot for ARK server management."""
 
@@ -90,24 +146,26 @@ class ArkDiscordBot(commands.Bot):
         await ctx.send(help_text)
 
     async def restart_command(self, ctx):
-        """Handle server restart command."""
+        """Handle server restart command with confirmation dialog."""
         try:
             logger.info(f"Server restart requested by {ctx.author}")
 
-            success = await self.kubernetes_manager.restart_server()
-
-            if success:
-                await ctx.send(
-                    "🔄 ARKサーバーの再起動を開始しました！サーバーがオンラインに戻るまでしばらくお待ちください。"
-                )
-            else:
-                await ctx.send(
-                    "❌ ARKサーバーの再起動に失敗しました。ログを確認するか管理者にお問い合わせください。"
-                )
+            # Create confirmation view
+            view = RestartConfirmationView(self)
+            
+            embed = discord.Embed(
+                title="⚠️ ARKサーバー再起動の確認",
+                description="本当にARKサーバーを再起動しますか？\n\n"
+                           "⚠️ **注意**: 再起動中はプレイヤーが切断され、"
+                           "サーバーが再度利用可能になるまで数分かかります。",
+                color=0xff9900
+            )
+            
+            await ctx.send(embed=embed, view=view)
 
         except Exception as e:
             logger.error(f"Error in restart command: {e}")
-            await ctx.send("❌ サーバー再起動中にエラーが発生しました。")
+            await ctx.send("❌ サーバー再起動コマンドでエラーが発生しました。")
 
     async def players_command(self, ctx):
         """Handle players list command."""

--- a/src/ark_discord_bot/discord_bot.py
+++ b/src/ark_discord_bot/discord_bot.py
@@ -16,28 +16,29 @@ logger = logging.getLogger(__name__)
 class RestartConfirmationView(discord.ui.View):
     """View for restart confirmation dialog."""
 
-    def __init__(self, bot: 'ArkDiscordBot', timeout=60):
+    def __init__(self, bot: "ArkDiscordBot", timeout=60):
         super().__init__(timeout=timeout)
         self.bot = bot
         self.confirmed = False
 
-    @discord.ui.button(label='再起動する', style=discord.ButtonStyle.danger, emoji='🔄')
-    async def confirm_restart(self, interaction: discord.Interaction, button: discord.ui.Button):
+    @discord.ui.button(label="再起動する", style=discord.ButtonStyle.danger, emoji="🔄")
+    async def confirm_restart(
+        self, interaction: discord.Interaction, button: discord.ui.Button  # pylint: disable=unused-argument
+    ):
         """Handle restart confirmation."""
         self.confirmed = True
-        
+
         # Disable all buttons
         for item in self.children:
             item.disabled = True
-        
+
         await interaction.response.edit_message(
-            content="🔄 ARKサーバーの再起動を開始しています...",
-            view=self
+            content="🔄 ARKサーバーの再起動を開始しています...", view=self
         )
-        
+
         try:
             success = await self.bot.kubernetes_manager.restart_server()
-            
+
             if success:
                 await interaction.followup.send(
                     "✅ ARKサーバーの再起動を開始しました！サーバーがオンラインに戻るまでしばらくお待ちください。"
@@ -48,18 +49,23 @@ class RestartConfirmationView(discord.ui.View):
                 )
         except Exception as e:
             logger.error(f"Error during server restart: {e}")
-            await interaction.followup.send("❌ サーバー再起動中にエラーが発生しました。")
+            await interaction.followup.send(
+                "❌ サーバー再起動中にエラーが発生しました。"
+            )
 
-    @discord.ui.button(label='キャンセル', style=discord.ButtonStyle.secondary, emoji='❌')
-    async def cancel_restart(self, interaction: discord.Interaction, button: discord.ui.Button):
+    @discord.ui.button(
+        label="キャンセル", style=discord.ButtonStyle.secondary, emoji="❌"
+    )
+    async def cancel_restart(
+        self, interaction: discord.Interaction, button: discord.ui.Button  # pylint: disable=unused-argument
+    ):
         """Handle restart cancellation."""
         # Disable all buttons
         for item in self.children:
             item.disabled = True
-        
+
         await interaction.response.edit_message(
-            content="❌ ARKサーバーの再起動がキャンセルされました。",
-            view=self
+            content="❌ ARKサーバーの再起動がキャンセルされました。", view=self
         )
 
     async def on_timeout(self):
@@ -152,15 +158,15 @@ class ArkDiscordBot(commands.Bot):
 
             # Create confirmation view
             view = RestartConfirmationView(self)
-            
+
             embed = discord.Embed(
                 title="⚠️ ARKサーバー再起動の確認",
                 description="本当にARKサーバーを再起動しますか？\n\n"
-                           "⚠️ **注意**: 再起動中はプレイヤーが切断され、"
-                           "サーバーが再度利用可能になるまで数分かかります。",
-                color=0xff9900
+                "⚠️ **注意**: 再起動中はプレイヤーが切断され、"
+                "サーバーが再度利用可能になるまで数分かかります。",
+                color=0xFF9900,
             )
-            
+
             await ctx.send(embed=embed, view=view)
 
         except Exception as e:

--- a/src/ark_discord_bot/discord_bot.py
+++ b/src/ark_discord_bot/discord_bot.py
@@ -23,7 +23,9 @@ class RestartConfirmationView(discord.ui.View):
 
     @discord.ui.button(label="再起動する", style=discord.ButtonStyle.danger, emoji="🔄")
     async def confirm_restart(
-        self, interaction: discord.Interaction, button: discord.ui.Button  # pylint: disable=unused-argument
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # pylint: disable=unused-argument
     ):
         """Handle restart confirmation."""
         self.confirmed = True
@@ -57,7 +59,9 @@ class RestartConfirmationView(discord.ui.View):
         label="キャンセル", style=discord.ButtonStyle.secondary, emoji="❌"
     )
     async def cancel_restart(
-        self, interaction: discord.Interaction, button: discord.ui.Button  # pylint: disable=unused-argument
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # pylint: disable=unused-argument
     ):
         """Handle restart cancellation."""
         # Disable all buttons

--- a/tests/test_discord_bot_simple.py
+++ b/tests/test_discord_bot_simple.py
@@ -50,7 +50,7 @@ class TestArkDiscordBotSimple:
 
     @pytest.mark.asyncio
     async def test_restart_command_success(self, mock_config):
-        """Test successful restart command."""
+        """Test restart command shows confirmation dialog."""
         with patch(
             "src.ark_discord_bot.discord_bot.KubernetesManager"
         ) as mock_k8s, patch("src.ark_discord_bot.discord_bot.RconManager"), patch(
@@ -69,11 +69,12 @@ class TestArkDiscordBotSimple:
 
             await bot.restart_command(mock_ctx)
 
-            # Verify restart was called and success message sent
-            bot.kubernetes_manager.restart_server.assert_called_once()
-            mock_ctx.send.assert_called_with(
-                "🔄 ARKサーバーの再起動を開始しました！サーバーがオンラインに戻るまでしばらくお待ちください。"
-            )
+            # Verify confirmation dialog was sent (not direct restart)
+            mock_ctx.send.assert_called_once()
+            args, kwargs = mock_ctx.send.call_args
+            assert "embed" in kwargs
+            assert "view" in kwargs
+            assert "ARKサーバー再起動の確認" in kwargs["embed"].title
 
     @pytest.mark.asyncio
     async def test_players_command_with_players(self, mock_config):


### PR DESCRIPTION
## Summary
• Add interactive confirmation dialog for `\!ark restart` command using Discord UI buttons
• Replace immediate restart execution with user-friendly confirmation step
• Implement proper error handling and user feedback throughout the process

## Changes
• **RestartConfirmationView class**: New Discord UI View with confirm/cancel buttons
• **Enhanced restart_command**: Shows warning embed with confirmation dialog instead of immediate execution
• **60-second timeout**: Automatic button disabling after timeout to prevent stale interactions
• **Updated tests**: Modified test case to verify confirmation dialog behavior

## Test plan
- [ ] Verify `\!ark restart` command shows confirmation dialog with proper warning message
- [ ] Test "再起動する" button executes actual server restart
- [ ] Test "キャンセル" button cancels operation without restarting
- [ ] Verify buttons are disabled after interaction to prevent duplicate actions
- [ ] Confirm 60-second timeout works correctly
- [ ] Run full test suite to ensure no regressions: `uv run pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.ai/code)