### PR TITLE
fix: !pal update失敗時に具体的なエラー理由をDiscordに表示

### DIFF
--- a/src/ark_discord_bot/core/commands.clj
+++ b/src/ark_discord_bot/core/commands.clj
@@ -115,8 +115,12 @@
 
 (defn format-pal-update-failed
   "Format PalWorld update failed message."
-  []
-  "❌ PalWorldサーバーの更新に失敗しました。GitHubトークンの設定やログを確認してください。")
+  ([] (format-pal-update-failed nil))
+  ([reason]
+   (str "❌ PalWorldサーバーの更新に失敗しました。"
+        (when (and reason (not (str/blank? reason)))
+          (str "\n理由: " reason))
+        "\nGitHubトークンの設定やログを確認してください。")))
 
 (defn format-pal-update-cancelled
   "Format PalWorld update cancelled message."

--- a/src/ark_discord_bot/system/gateway_event_loop.clj
+++ b/src/ark_discord_bot/system/gateway_event_loop.clj
@@ -8,6 +8,7 @@
               [ark-discord-bot.effects.kubernetes :as k8s]
               [ark-discord-bot.effects.rcon :as rcon]
               [clojure.core.async :as async :refer [go-loop alt! <! <!!]]
+              [clojure.string :as str]
               [integrant.core :as ig]))
 
 (defn- log [level msg]
@@ -96,7 +97,7 @@
                                  (:palserver-workflow config) (:palserver-branch config))))
 
 (defn- dispatch-pal-workflow [github-client config]
-  (if (nil? (:github-token config))
+  (if (or (nil? (:github-token config)) (str/blank? (:github-token config)))
     (do (log :error "GITHUB_TOKEN not configured") {:error "GITHUB_TOKEN not configured"})
     (let [result (call-dispatch-workflow github-client config)]
       (if (:success result)
@@ -107,7 +108,7 @@
 (defn- pal-update-result-message [result]
   (if (:success result)
     (commands/format-pal-update-success)
-    (commands/format-pal-update-failed)))
+    (commands/format-pal-update-failed (:error result))))
 
 (defn- try-acquire-pal-update-lock
   "Atomically acquire the pal update in-progress lock.

--- a/test/ark_discord_bot/core/commands_test.clj
+++ b/test/ark_discord_bot/core/commands_test.clj
@@ -60,5 +60,18 @@
       (is (str/includes? msg "⚠️"))
       (is (str/includes? msg "実行中")))))
 
+(deftest test-format-pal-update-failed
+  (testing "returns failure message with error emoji when called with no args"
+    (let [msg (commands/format-pal-update-failed)]
+      (is (str/includes? msg "❌"))))
+  (testing "includes reason in failure message when reason is provided"
+    (let [msg (commands/format-pal-update-failed "GITHUB_TOKEN not configured")]
+      (is (str/includes? msg "❌"))
+      (is (str/includes? msg "GITHUB_TOKEN not configured"))))
+  (testing "includes API error detail when GitHub API error is provided"
+    (let [msg (commands/format-pal-update-failed "GitHub API error: 401")]
+      (is (str/includes? msg "❌"))
+      (is (str/includes? msg "GitHub API error: 401")))))
+
 ;; Run tests when loaded
 (clojure.test/run-tests 'ark-discord-bot.core.commands-test)

--- a/test/ark_discord_bot/system/gateway_event_loop_test.clj
+++ b/test/ark_discord_bot/system/gateway_event_loop_test.clj
@@ -36,9 +36,11 @@
   (testing "returns success message when dispatch succeeds"
     (let [msg (#'event-loop/pal-update-result-message {:success true})]
       (is (str/includes? msg "✅"))))
-  (testing "returns failure message when dispatch fails with error"
+  (testing "returns failure message with error reason when dispatch fails"
     (let [msg (#'event-loop/pal-update-result-message {:error "GitHub API error: 403"})]
-      (is (str/includes? msg "❌"))))
-  (testing "returns failure message when github-token not configured"
+      (is (str/includes? msg "❌"))
+      (is (str/includes? msg "GitHub API error: 403"))))
+  (testing "returns failure message with not-configured reason"
     (let [msg (#'event-loop/pal-update-result-message {:error "GITHUB_TOKEN not configured"})]
-      (is (str/includes? msg "❌")))))
+      (is (str/includes? msg "❌"))
+      (is (str/includes? msg "GITHUB_TOKEN not configured")))))


### PR DESCRIPTION
## Summary

- `!pal update`がGITHUB_TOKEN未設定やGitHub APIエラーで失敗した際、Discordに具体的な理由を表示するよう改善
- `format-pal-update-failed`をオプション引数対応に変更（`reason`を含めるか否か）
- `dispatch-pal-workflow`でblank文字列チェックを追加（ExternalSecretが空のSecretを作成した場合も検出）

## 背景

SSM Parameterから`GITHUB_TOKEN`が渡されない場合、以前は「GitHubトークンの設定やログを確認してください」という汎用メッセージのみ表示されていた。これでは問題の原因（トークン未設定 vs API認証失敗 vs その他のエラー）がわかりにくかった。

## 変更後のメッセージ例

GITHUB_TOKEN未設定時:
```
❌ PalWorldサーバーの更新に失敗しました。
理由: GITHUB_TOKEN not configured
GitHubトークンの設定やログを確認してください。
```

GitHub API 401エラー時:
```
❌ PalWorldサーバーの更新に失敗しました。
理由: GitHub API error: 401 {"message":"Bad credentials"...}
GitHubトークンの設定やログを確認してください。
```

## Test plan

- [x] `test-format-pal-update-failed` - 理由あり/なし両方のケースをテスト
- [x] `pal-update-result-message-test` - エラー理由がメッセージに含まれることを確認
- GitHub Actions CI (lint/test) で確認

## SSM Parameter設定の確認事項（インフラ）

この修正とは別に、以下のインフラ確認が必要です：
1. External Secrets Operator がクラスタにインストール済みか
2. `ClusterSecretStore: aws-parameter-store` が設定済みか
3. SSM Parameter `/ark-discord-bot/github-token` に`workflow`スコープ付きのPATが設定済みか
4. ESO が使用するIAMロールに `ssm:GetParameter` 権限があるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)